### PR TITLE
Added information to build successfully

### DIFF
--- a/Delay/README.md
+++ b/Delay/README.md
@@ -4,10 +4,14 @@ This assertion adds a delay of X milliseconds to a policy. It effectively behave
 # Build
 In order to build the assertion run `gradle build`.
 
+> **Note**: Tested with Gradle 6.9.4 and JDK "Temurin" 11
+
 This will compile, test, and create the jar file. It will be available in `build/libs`
 
 # Adding Libraries
 In order to build the custom assertion, the Layer7 API Gateway API jar is required to be put into the lib directory.
+
+> You may find the JAR in the `lib` folder under the Policy Manager install, e.g. `/Applications/PolicyManager-11.app/lib/layer7-api-8.11.02.14811.jar`
 
 # Run
 Docker version of Gateway greatly helps us to deploy assertions / RESTMAN bundles quickly. Please follow the steps below to run the container Gateway prepopulated with this example assertion and example services.

--- a/Delay/README.md
+++ b/Delay/README.md
@@ -4,7 +4,7 @@ This assertion adds a delay of X milliseconds to a policy. It effectively behave
 # Build
 In order to build the assertion run `gradle build`.
 
-> **Note**: Tested with Gradle 6.9.4 and JDK "Temurin" 11
+> **Note**: Tested with Gradle 8.9 (latest) and JDK "Temurin" 11
 
 This will compile, test, and create the jar file. It will be available in `build/libs`
 

--- a/Delay/build.gradle
+++ b/Delay/build.gradle
@@ -10,7 +10,7 @@ group = 'com.ca.apim.gateway.assertion'
 version = '1.1.0'
 
 description = 'This assertion adds a delay of X milliseconds to a policy. It effectively behaves as a sleep action during policy execution. It is intended be used for development and testing purposes only - not production.'
-jar.baseName = 'DelayAssertion'
+jar.archiveBaseName = 'DelayAssertion'
 
 repositories {
     mavenCentral()
@@ -19,14 +19,16 @@ repositories {
     }
 }
 
-sourceCompatibility = JavaVersion.VERSION_11
-targetCompatibility = JavaVersion.VERSION_11
+java {
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
+}
 
 configurations {
     // dependencies that do not need to be bundled in the assertion's jar
     provided
 
-    compile {
+    implementation {
         extendsFrom provided
     }
 }
@@ -34,13 +36,13 @@ configurations {
 dependencies {
     provided 'com.l7tech:layer7-api:8.11.02.+'
 
-    testCompile group: 'org.mockito', name: 'mockito-core', version: '2.28.2'
-    testCompile group: 'junit', name: 'junit', version: '4.13'
+    testImplementation group: 'org.mockito', name: 'mockito-core', version: '5.12.0'
+    testImplementation group: 'org.junit.vintage', name: 'junit-vintage-engine', version: '5.10.3'
 }
 
 project.jar {
     // add dependencies to the jar's `lib` directory
     into('lib') {
-        from project.configurations.runtime - project.configurations.provided
+        from project.configurations.runtimeClasspath - project.configurations.provided
     }
 }

--- a/Delay/build.gradle
+++ b/Delay/build.gradle
@@ -32,7 +32,7 @@ configurations {
 }
 
 dependencies {
-    provided 'com.l7tech:layer7-api:8.11.01.+'
+    provided 'com.l7tech:layer7-api:8.11.02.+'
 
     testCompile group: 'org.mockito', name: 'mockito-core', version: '2.28.2'
     testCompile group: 'junit', name: 'junit', version: '4.13'

--- a/Delay/docker-compose.yml
+++ b/Delay/docker-compose.yml
@@ -5,8 +5,8 @@
 version: '3.4'
 services:
   gateway-dev:
-    hostname: gateway-dev
-    image: caapim/gateway:10.1.00
+    hostname: gateway-delay
+    image: caapim/gateway:11.1.00
     ports:
       - "8080:8080"
       - "8443:8443"


### PR DESCRIPTION
Added some notes about working gradle version (6.9.4, gradle 7.0+ fails) to `README.md` and updated the required version of `layer7-api.jar` to match the one shipped with Policy Manager 11